### PR TITLE
Fix ignoring closing cancelled

### DIFF
--- a/Dragablz/TabablzControl.cs
+++ b/Dragablz/TabablzControl.cs
@@ -907,7 +907,8 @@ namespace Dragablz
                     .FirstOrDefault(
                         other =>
                             other.InterTabController != null &&
-                            other.InterTabController.Partition == InterTabController.Partition);
+                            other.InterTabController.Partition == InterTabController.Partition &&
+                            window != Window.GetWindow(other));
             if (target == null) return;
 
             foreach (var item in orphanedItems.Select(orphanedItem => _dragablzItemsControl.ItemContainerGenerator.ItemFromContainer(orphanedItem)))

--- a/Dragablz/TabablzControl.cs
+++ b/Dragablz/TabablzControl.cs
@@ -882,6 +882,8 @@ namespace Dragablz
 
         private void WindowOnClosing(object sender, CancelEventArgs cancelEventArgs)
         {
+            if (cancelEventArgs.Cancel) return;
+
             _windowSubscription.Disposable = Disposable.Empty;
             if (!ConsolidateOrphanedItems || InterTabController == null) return;
 


### PR DESCRIPTION
# Problem

When closing a window you can cancel doing so via the `Widow.Closing` event, when doing so `TabablzControl` would ignore this and still try and move its contents to another window is `TabablzControl.ConsolidateOrphanedItems` is set which will result in changing the layout of the program despite the user has cancelled closing the program.

If the window contains multiple `TabablzControl` within a `Layout` then their children has a chance of being moved multiple times in this process, depending on the child this may take some time.

# Solution

To check the cancelled flag before running the code and unsubscribing to the closing event and to ensure that the target `TabablzControl` is not in the same window.